### PR TITLE
feat: 해더 푸터 추가 + 메인 화면 Layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Vite + React</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root" class="bg-base-100"></div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@heroicons/react": "^2.1.1",
     "@tanstack/react-query": "^5.17.9",
     "@vitejs/plugin-react": "^4.2.1",
     "axios": "^1.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@emotion/styled':
     specifier: ^11.11.0
     version: 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.47)(react@18.2.0)
+  '@heroicons/react':
+    specifier: ^2.1.1
+    version: 2.1.1(react@18.2.0)
   '@tanstack/react-query':
     specifier: ^5.17.9
     version: 5.17.9(react@18.2.0)
@@ -948,6 +951,14 @@ packages:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
+
+  /@heroicons/react@2.1.1(react@18.2.0):
+    resolution: {integrity: sha512-JyyN9Lo66kirbCMuMMRPtJxtKJoIsXKS569ebHGGRKbl8s4CtUfLnyKJxteA+vIKySocO4s1SkTkGS4xtG/yEA==}
+    peerDependencies:
+      react: '>= 16'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}

--- a/src/components/WithLayout.js
+++ b/src/components/WithLayout.js
@@ -20,7 +20,7 @@ const DelayedComponent = lazy(() =>
  */
 export default function WithLayout() {
   return (
-    <>
+    <div className="flex flex-col justify-between h-screen">
       <Header />
       {/* <Popup /> */}
       <Suspense fallback={<div>대기중</div>}>
@@ -29,9 +29,11 @@ export default function WithLayout() {
             이는 React Router의 중첩된 라우팅 구조를 활용하는데 중요한 역할을 합니다.
             예시로 router.js routeConfig의 element를 넣습니다.
             */}
-        <Outlet />
-        <Footer />
+        <div className="h-full">
+          <Outlet />
+        </div>
       </Suspense>
-    </>
+      <Footer />
+    </div>
   );
 }

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -1,3 +1,9 @@
 export default function Footer() {
-  return <div>index</div>;
+  return (
+    <footer className="footer footer-center p-4 bg-base-200 text-base-content">
+      <aside>
+        <p>Copyright © 2024 - PineMarket</p>
+      </aside>
+    </footer>
+  );
 }

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,3 +1,66 @@
+import { Bars3Icon } from "@heroicons/react/16/solid";
+import { MagnifyingGlassIcon } from "@heroicons/react/16/solid";
+
 export default function Header() {
-  return <div>index</div>;
+  return (
+    <div className="navbar bg-base-200">
+      <div className="navbar-start">
+        <div className="dropdown">
+          <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
+            <Bars3Icon className="w-8 h-8" />
+          </div>
+          <ul
+            tabIndex={0}
+            className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+            <li>
+              <a>Homepage</a>
+            </li>
+            <li>
+              <a>Portfolio</a>
+            </li>
+            <li>
+              <a>About</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div className="navbar-center">
+        <a className="btn btn-ghost text-xl">PineMarket</a>
+      </div>
+      <div className="navbar-end">
+        <button className="btn btn-ghost btn-circle">
+          <MagnifyingGlassIcon className="w-6 h-6" />
+        </button>
+        <div className="dropdown dropdown-end">
+          <div
+            tabIndex={0}
+            role="button"
+            className="btn btn-ghost btn-circle avatar">
+            <div className="w-10 rounded-full">
+              <img
+                alt="Tailwind CSS Navbar component"
+                src="https://daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg"
+              />
+            </div>
+          </div>
+          <ul
+            tabIndex={0}
+            className="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52">
+            <li>
+              <a className="justify-between">
+                Profile
+                <span className="badge">New</span>
+              </a>
+            </li>
+            <li>
+              <a>Settings</a>
+            </li>
+            <li>
+              <a>Logout</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -1,0 +1,17 @@
+export const LoginPage = () => {
+  return (
+    <>
+      <details className="dropdown">
+        <summary className="m-1 btn">open or close</summary>
+        <ul className="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+          <li>
+            <a>Item 1</a>
+          </li>
+          <li>
+            <a>Item 2</a>
+          </li>
+        </ul>
+      </details>
+    </>
+  );
+};

--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,7 @@ import ProductsPage from "@/pages/product/ProductsPage";
 import { ROUTES } from "@/utils/constants/routePaths";
 import { createBrowserRouter } from "react-router-dom";
 import ProductDetailPage from "./pages/product/ProductDetailPage";
+import { LoginPage } from "./pages/login/LoginPage";
 // 코드 스플리팅을 위해 React.lazy를 사용하는 주석 처리된 예시입니다.
 // 현재는 직접 임포트를 사용하고 있지만, 나중에 필요시 아래의 코드로 대체할 수 있습니다.
 // const ProductPage = React.lazy(() => import("Pages/ProductPage"));
@@ -17,6 +18,7 @@ export const routeConfig = [
   // `index: true`는 이 라우트가 자식 라우트보다 우선순위가 높음을 나타냅니다.
   { path: ROUTES.HOME, element: <ProductsPage />, index: true },
   { path: ROUTES.PRODUCT, element: <ProductDetailPage /> },
+  { path: ROUTES.LOGIN, element: <LoginPage /> },
 
   // 404 Not Found 페이지 경로, NotFoundPage 컴포넌트를 렌더링합니다.
   // 와일드카드('*') 경로를 사용하여 예상치 못한 모든 경로에서 NotFoundPage를 띄웁니다.


### PR DESCRIPTION
# PR 제목 📝

해더 푸터 추가 + 메인 화면 Layout

## 개요 📋

해더 푸터 추가 + 메인 화면 Layout

## 변경 사항 🔄

해더와 푸터가 변경되고 기본적인 디자인이 설정 됬습니다.

기본 구조는 높이 스크린에 맞는 레이아웃 + 해더와 푸터가 위 아래를 차지하고

나머지 Outlet이 full로 채우는 구조입니다.

## 추가 정보 ℹ️

![chrome_cclDjanjj8](https://github.com/nakjun12/Market/assets/97251710/28f466e6-9abb-498a-b95a-d3b62ba72a7e)

