### PR TITLE
feat: 해더의 로그인 및 홈으로 이동하는 링크 추가와 컴포넌트 분리

### DIFF
--- a/src/components/header/components/LoginMenuList.js
+++ b/src/components/header/components/LoginMenuList.js
@@ -1,0 +1,37 @@
+import { ROUTES } from "@/utils/constants/routePaths";
+import { useNavigate } from "react-router-dom";
+
+export const LoginMenuList = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="dropdown dropdown-end">
+      <div
+        tabIndex={0}
+        role="button"
+        className="btn btn-ghost btn-circle avatar">
+        <div className="w-10 rounded-full">
+          <svg
+            className="absolute w-10 h-10 text-gray-400"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg">
+            <path
+              fillRule="evenodd"
+              d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+              clipRule="evenodd"></path>
+          </svg>
+        </div>
+      </div>
+      <ul
+        tabIndex={0}
+        className="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52">
+        <li>
+          <div onClick={() => navigate(ROUTES.LOGIN)}>Login</div>
+        </li>
+        <li>
+          <div onClick={() => navigate(ROUTES.JOIN)}>Join</div>
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/src/components/header/components/LogoutMenuList.js
+++ b/src/components/header/components/LogoutMenuList.js
@@ -1,0 +1,33 @@
+import useAuthStore from "@/utils/hooks/store/useAuthStore";
+
+export const LogoutMenuList = () => {
+  const { logout } = useAuthStore();
+  return (
+    <div className="dropdown dropdown-end">
+      <div
+        tabIndex={0}
+        role="button"
+        className="btn btn-ghost btn-circle avatar">
+        <div className="w-10 rounded-full">
+          <img
+            alt="Tailwind CSS Navbar component"
+            src="https://daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg"
+          />
+        </div>
+      </div>
+      <ul
+        tabIndex={0}
+        className="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52">
+        <li>
+          <a className="justify-between">
+            Profile
+            <span className="badge">New</span>
+          </a>
+        </li>
+        <li>
+          <div onClick={() => logout()}>Logout</div>
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,10 +1,15 @@
-import { Bars3Icon } from "@heroicons/react/16/solid";
+import { ROUTES } from "@/utils/constants/routePaths";
+import useAuthStore from "@/utils/hooks/store/useAuthStore";
+import { HomeIcon } from "@heroicons/react/16/solid";
 import { MagnifyingGlassIcon } from "@heroicons/react/16/solid";
-import { useNavigate, useLocation } from "react-router-dom";
-
+import { useNavigate } from "react-router-dom";
+import { LogoutMenuList } from "./components/LogoutMenuList";
+import { LoginMenuList } from "./components/LoginMenuList";
+import { useLocation } from "react-router-dom";
 export default function Header() {
-  const navigate = useNavigate();
   const location = useLocation();
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuthStore();
 
   const handleSearchIconClick = () => {
     // 현재 경로가 검색 페이지가 아닌 경우에만 동작하도록 처리
@@ -16,27 +21,14 @@ export default function Header() {
   return (
     <div className="navbar bg-base-200">
       <div className="navbar-start">
-        <div className="dropdown">
-          <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
-            <Bars3Icon className="w-8 h-8" />
-          </div>
-          <ul
-            tabIndex={0}
-            className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
-            <li>
-              <a>Homepage</a>
-            </li>
-            <li>
-              <a>Portfolio</a>
-            </li>
-            <li>
-              <a>About</a>
-            </li>
-          </ul>
+        <div
+          tabIndex={0}
+          role="button"
+          className="flex-col btn"
+          onClick={() => navigate(ROUTES.HOME)}>
+          <HomeIcon className="w-8 h-8" />
+          <div className="text-lg">PineMarket</div>
         </div>
-      </div>
-      <div className="navbar-center">
-        <a className="btn btn-ghost text-xl">PineMarket</a>
       </div>
       <div className="navbar-end">
         <button
@@ -44,35 +36,7 @@ export default function Header() {
           onClick={handleSearchIconClick}>
           <MagnifyingGlassIcon className="w-6 h-6" />
         </button>
-        <div className="dropdown dropdown-end">
-          <div
-            tabIndex={0}
-            role="button"
-            className="btn btn-ghost btn-circle avatar">
-            <div className="w-10 rounded-full">
-              <img
-                alt="Tailwind CSS Navbar component"
-                src="https://daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg"
-              />
-            </div>
-          </div>
-          <ul
-            tabIndex={0}
-            className="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52">
-            <li>
-              <a className="justify-between">
-                Profile
-                <span className="badge">New</span>
-              </a>
-            </li>
-            <li>
-              <a>Settings</a>
-            </li>
-            <li>
-              <a>Logout</a>
-            </li>
-          </ul>
-        </div>
+        {isAuthenticated ? <LogoutMenuList /> : <LoginMenuList />}
       </div>
     </div>
   );

--- a/src/pages/join/components/JoinForm.js
+++ b/src/pages/join/components/JoinForm.js
@@ -155,7 +155,7 @@ export const JoinForm = () => {
                     이미 회원 가입하셨나요?
                   </p>
                   <div
-                    onClick={() => navigate("/login")}
+                    onClick={() => navigate(ROUTES.LOGIN)}
                     className="text-blue-500 font-black hover:underline">
                     Login here
                   </div>

--- a/src/pages/login/components/LoginForm.js
+++ b/src/pages/login/components/LoginForm.js
@@ -119,7 +119,7 @@ export const LoginForm = () => {
                     가입이 필요하신가요?
                   </p>
                   <div
-                    onClick={() => navigate("/join")}
+                    onClick={() => navigate(ROUTES.JOIN)}
                     className="text-blue-500 font-black hover:underline">
                     Join here
                   </div>


### PR DESCRIPTION
## PR 제목 📝

해더의 로그인 및 홈으로 이동하는 링크 추가와 컴포넌트 분리

## 개요 📋

해더를 회의에서 논의한 대로 변경

+ 로그인과 조인의 버튼에서 하드코딩된 URL 링크가 있어 해당부분 일부 수정

## 변경 사항 🔄

![chrome_cYz7FNEIpL](https://github.com/nakjun12/Market/assets/97251710/40dfba0d-09fe-43f6-bb95-88dd24fe14e1)

