### PR TITLE
fix: loading 문구 중복으로 ProductList에서 한번에 처리

### DIFF
--- a/src/pages/product/ProductSearchResultPage.js
+++ b/src/pages/product/ProductSearchResultPage.js
@@ -98,8 +98,6 @@ const ProductSearchResultPage = () => {
         hasMore={hasMore}
       />
 
-      {loading && <div>로딩 중...</div>}
-      {!loading && !hasMore && <div>더 이상 아이템이 없습니다.</div>}
       <div ref={loaderRef}></div>
     </div>
   );

--- a/src/pages/product/ProductsPage.js
+++ b/src/pages/product/ProductsPage.js
@@ -79,8 +79,6 @@ export default function ProductsPage() {
         hasMore={hasMore}
       />
 
-      {loading && <div>로딩 중...</div>}
-      {!loading && !hasMore && <div>더 이상 아이템이 없습니다.</div>}
       <div ref={loaderRef}></div>
     </div>
   );

--- a/src/pages/product/components/ProductList.js
+++ b/src/pages/product/components/ProductList.js
@@ -56,51 +56,34 @@ const ProductList = ({ productList, fetchMoreData, loading, hasMore }) => {
 
   return (
     <ProductListWrap>
-      {productList && productList.length > 0 ? (
-        <>
-          <CardWrap>
-            {productList.map((product, index) => {
-              if (productList.length === index + 1) {
-                return (
-                  <Card
-                    key={index}
-                    ref={lastProductRef}
-                    className="productCard"
-                    // onClick={() => handleProductPage(product.id)}
-                  >
-                    {/* 추후에 상품 디테일 페이지에 연결 ! */}
-                    <CardImg src={product.imgUrl} alt={product.title} />
-                    <ProductTitle>{product.title}</ProductTitle>
-                  </Card>
-                );
-              } else {
-                return (
-                  <Card
-                    key={index}
-                    className="productCard"
-                    // onClick={() => handleProductPage(product.id)}
-                    /* 추후에 상품 디테일 페이지에 연결 ! */
-                  >
-                    <CardImg src={product.imgUrl} alt={product.title} />
-
-                    <ProductBadge>{product.content}</ProductBadge>
-                    <ProductTitle>{product.title}</ProductTitle>
-                  </Card>
-                );
-              }
-            })}
-          </CardWrap>
+      {loading && <NoticeMsg>로딩 중...</NoticeMsg>}
+      {!loading && productList && productList.length > 0 && (
+        <CardWrap>
+          {productList.map((product, index) => (
+            <Card
+              key={index}
+              ref={index === productList.length - 1 ? lastProductRef : null}
+              className="productCard"
+              // onClick={() => handleProductPage(product.id)}
+            >
+              {/* 추후에 상품 디테일 페이지에 연결 ! */}
+              <CardImg src={product.imgUrl} alt={product.title} />
+              {index !== productList.length - 1 && (
+                <ProductBadge>{product.content}</ProductBadge>
+              )}
+              <ProductTitle>{product.title}</ProductTitle>
+            </Card>
+          ))}
           <TopButton
             className="btn btn-neutral"
             show={showTopButton}
             onClick={scrollToTop}>
             TOP
           </TopButton>
-        </>
-      ) : (
-        <NoticeMsg>
-          {productList ? "상품이 없습니다." : "상품을 불러오는 중입니다..."}
-        </NoticeMsg>
+        </CardWrap>
+      )}
+      {!loading && (!productList || productList.length === 0) && (
+        <NoticeMsg>상품이 없습니다.</NoticeMsg>
       )}
     </ProductListWrap>
   );


### PR DESCRIPTION
## PR 제목 📝
- 검색 / 메인페이지와 ProductList에서 loading 중 문구를 중복으로 사용하여 ProdudctList에서 관리하도록 수정
<!-- 개발한 기능 또는 해결한 이슈의 요약을 간단하게 작성합니다. -->



## 변경 사항 🔄
- 기존에 ProductList에 Props로 전달되던 loading을 내려받아, '로딩 중...' 문구 노출
- productList.length가 없을 때 '상품이 없습니다' 문구 노출
<!-- 변경된 파일 목록과 각 변경점에 대한 설명을 포함합니다. -->

## 추가 정보 ℹ️

<!-- 이 변경사항이 필요한 이유, 선택한 해결 방법, 고려한 대안 등에 대한 추가적인 컨텍스트를 제공합니다. -->
