### PR TITLE
feat: 공용 Loading 스피너 컴포넌트 추가, 로컬스토리지 사용 불가 시 로직 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",
+    "react-spinners": "^0.13.8",
     "swiper": "^11.0.5",
     "zustand": "^4.4.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   react-router-dom:
     specifier: ^6.21.1
     version: 6.21.1(react-dom@18.2.0)(react@18.2.0)
+  react-spinners:
+    specifier: ^0.13.8
+    version: 0.13.8(react-dom@18.2.0)(react@18.2.0)
   swiper:
     specifier: ^11.0.5
     version: 11.0.5
@@ -4821,6 +4824,16 @@ packages:
     dependencies:
       '@remix-run/router': 1.14.1
       react: 18.2.0
+    dev: false
+
+  /react-spinners@0.13.8(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { BeatLoader } from "react-spinners";
+import styled from "@emotion/styled";
+
+const Loading = () => {
+  return (
+    <LoadingWrap>
+      <BeatLoader />
+    </LoadingWrap>
+  );
+};
+export default Loading;
+
+const LoadingWrap = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;

--- a/src/pages/product/ProductSearchResultPage.js
+++ b/src/pages/product/ProductSearchResultPage.js
@@ -1,88 +1,11 @@
 // ProductSearchResult.js
 
 import styled from "@emotion/styled";
-import { getPublishedPosts } from "@/api/marketApi";
-import { useState } from "react";
-import { useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import ProductList from "./components/ProductList";
 
 const ProductSearchResultPage = () => {
   const { keyword } = useParams(); // 검색어
-  const [productList, setProductList] = useState(); // 넘겨줄 상품 리스트 배열
-  const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [page, setPage] = useState(1);
-  const loaderRef = useRef(null);
-
-  const fetchMoreData = async () => {
-    if (loading || !hasMore) return;
-
-    try {
-      setLoading(true);
-      const resData = await getPublishedPosts({
-        page: page !== 1 ? page + 1 : page,
-        limit: 16,
-        query: keyword ? keyword : "",
-        orderBy: "createdAt",
-        direction: "asc"
-      });
-
-      if (resData.data?.data?.length > 0) {
-        setProductList((prevList) => [...prevList, ...resData.data.data]);
-        setPage(page + 1);
-      } else {
-        setHasMore(false);
-      }
-    } catch (error) {
-      console.error("데이터 추가 불러오기 실패:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    searchApi(keyword);
-  }, [keyword]);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      if (loaderRef.current) {
-        const { scrollTop, clientHeight, scrollHeight } = loaderRef.current;
-
-        if (scrollHeight - scrollTop === clientHeight) {
-          fetchMoreData();
-        }
-      }
-    };
-
-    if (loaderRef.current) {
-      // 값이 없는 경우(null) 페이지 이동 시 에러 발생하기 때문에 null이 아닐때만 동작하도록 함
-      loaderRef.current.addEventListener("scroll", handleScroll);
-    }
-
-    return () => {
-      if (loaderRef.current) {
-        loaderRef.current.removeEventListener("scroll", handleScroll);
-      }
-    };
-  }, [fetchMoreData]);
-
-  const searchApi = async (keyword) => {
-    try {
-      const resData = await getPublishedPosts({
-        page: 1,
-        limit: 10,
-        query: keyword ? keyword : "",
-        orderBy: "createdAt",
-        direction: "asc"
-      });
-
-      setProductList(resData.data.data);
-    } catch (error) {
-      console.error("검색 API 호출 실패:", error);
-    }
-  };
 
   return (
     <div>
@@ -91,14 +14,7 @@ const ProductSearchResultPage = () => {
         결과입니다.
       </SearchResultText>
 
-      <ProductList
-        productList={productList}
-        fetchMoreData={fetchMoreData}
-        loading={loading}
-        hasMore={hasMore}
-      />
-
-      <div ref={loaderRef}></div>
+      <ProductList keyword={keyword} />
     </div>
   );
 };

--- a/src/pages/product/ProductSearchResultPage.js
+++ b/src/pages/product/ProductSearchResultPage.js
@@ -98,8 +98,6 @@ const ProductSearchResultPage = () => {
         hasMore={hasMore}
       />
 
-      {loading && <div>로딩 중...</div>}
-      {!loading && !hasMore && <div>더 이상 아이템이 없습니다.</div>}
       <div ref={loaderRef}></div>
     </div>
   );

--- a/src/pages/product/ProductSearchResultPage.js
+++ b/src/pages/product/ProductSearchResultPage.js
@@ -28,7 +28,7 @@ const ProductSearchResultPage = () => {
         direction: "asc"
       });
 
-      if (resData.data.data.length > 0) {
+      if (resData.data?.data?.length > 0) {
         setProductList((prevList) => [...prevList, ...resData.data.data]);
         setPage(page + 1);
       } else {

--- a/src/pages/product/ProductsPage.js
+++ b/src/pages/product/ProductsPage.js
@@ -1,85 +1,15 @@
-import { useEffect } from "react";
 import ProductList from "./components/ProductList";
 import styled from "@emotion/styled";
-import { useState } from "react";
-import { useRef } from "react";
-import { getPublishedPosts } from "@/api/marketApi";
 
 // 처음 진입하면 보이는 메인 페이지
 // api를 호출하여 ProcudtList에 정보를 넘겨서 보여주도록 함
 // 스크롤을 통해 더 많은 상품을 동적으로 로드
 export default function ProductsPage() {
-  const [productList, setProductList] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [page, setPage] = useState(1);
-  const loaderRef = useRef(null);
-
-  const fetchMoreData = async () => {
-    if (loading || !hasMore) return;
-
-    try {
-      setLoading(true);
-      const resData = await getPublishedPosts({
-        page: page !== 1 ? page + 1 : page,
-        limit: 10,
-        query: "",
-        orderBy: "createdAt",
-        direction: "asc"
-      });
-
-      if (resData.data?.data?.length > 0) {
-        setProductList((prevList) => [...prevList, ...resData.data.data]);
-        setPage(page + 1);
-      } else {
-        setHasMore(false);
-      }
-    } catch (error) {
-      console.error("데이터 추가 불러오기 실패:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    const handleScroll = () => {
-      if (loaderRef.current) {
-        const { scrollTop, clientHeight, scrollHeight } = loaderRef.current;
-
-        if (scrollHeight - scrollTop === clientHeight) {
-          fetchMoreData();
-        }
-      }
-    };
-
-    if (loaderRef.current) {
-      // 값이 없는 경우(null) 페이지 이동 시 에러 발생하기 때문에 null이 아닐때만 동작하도록 함
-      loaderRef.current.addEventListener("scroll", handleScroll);
-    }
-
-    return () => {
-      if (loaderRef.current) {
-        loaderRef.current.removeEventListener("scroll", handleScroll);
-      }
-    };
-  }, [fetchMoreData]);
-
-  useEffect(() => {
-    fetchMoreData();
-  }, []);
-
   return (
     <div>
       <ProductPageText>원하시는 상품을 찾아보세요.</ProductPageText>
 
-      <ProductList
-        productList={productList}
-        fetchMoreData={fetchMoreData}
-        loading={loading}
-        hasMore={hasMore}
-      />
-
-      <div ref={loaderRef}></div>
+      <ProductList />
     </div>
   );
 }

--- a/src/pages/product/ProductsPage.js
+++ b/src/pages/product/ProductsPage.js
@@ -28,7 +28,7 @@ export default function ProductsPage() {
         direction: "asc"
       });
 
-      if (resData.data.data.length > 0) {
+      if (resData.data?.data?.length > 0) {
         setProductList((prevList) => [...prevList, ...resData.data.data]);
         setPage(page + 1);
       } else {

--- a/src/pages/product/ProductsPage.js
+++ b/src/pages/product/ProductsPage.js
@@ -79,8 +79,6 @@ export default function ProductsPage() {
         hasMore={hasMore}
       />
 
-      {loading && <div>로딩 중...</div>}
-      {!loading && !hasMore && <div>더 이상 아이템이 없습니다.</div>}
       <div ref={loaderRef}></div>
     </div>
   );

--- a/src/pages/product/components/ProductList.js
+++ b/src/pages/product/components/ProductList.js
@@ -51,43 +51,33 @@ const ProductList = ({ productList, fetchMoreData, loading, hasMore }) => {
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
-  }, []);
+  }, [productList]);
 
   return (
     <ProductListWrap>
       {productList && productList.length > 0 ? (
         <>
           <CardWrap>
-            {productList.map((product, index) => {
-              if (productList.length === index + 1) {
-                return (
-                  <Card
-                    key={index}
-                    ref={lastProductRef}
-                    className="productCard"
-                    // onClick={() => handleProductPage(product.id)}
-                  >
-                    {/* 추후에 상품 디테일 페이지에 연결 ! */}
-                    <CardImg src={product.imgUrls[0]} alt={product.title} />
+            {productList.map((product, index) => (
+              <Card
+                key={index}
+                ref={index === productList.length - 1 ? lastProductRef : null}
+                className="productCard"
+                // onClick={() => handleProductPage(product.id)}
+              >
+                {/* 추후에 상품 디테일 페이지에 연결 ! */}
+                <CardImg src={product.imgUrls[0]} alt={product.title} />
+                {index === productList.length - 1 ? (
+                  <ProductTitle>{product.title}</ProductTitle>
+                ) : (
+                  <>
+                    <ProductBadge>{product.location}</ProductBadge>
                     <ProductTitle>{product.title}</ProductTitle>
-                  </Card>
-                );
-              } else {
-                return (
-                  <Card
-                    key={index}
-                    className="productCard"
-                    // onClick={() => handleProductPage(product.id)}
-                    /* 추후에 상품 디테일 페이지에 연결 ! */
-                  >
-                    <CardImg src={product.imgUrls[0]} alt={product.title} />
-
-                    <ProductBadge>{product.content}</ProductBadge>
-                    <ProductTitle>{product.title}</ProductTitle>
-                  </Card>
-                );
-              }
-            })}
+                    <ProductPrice>{product.price}원</ProductPrice>
+                  </>
+                )}
+              </Card>
+            ))}
           </CardWrap>
           <TopButton
             className="btn btn-neutral"
@@ -98,7 +88,9 @@ const ProductList = ({ productList, fetchMoreData, loading, hasMore }) => {
         </>
       ) : (
         <NoticeMsg>
-          {productList ? "상품이 없습니다." : "상품을 불러오는 중입니다..."}
+          {!loading && productList
+            ? "상품이 없습니다."
+            : "상품을 불러오는 중입니다..."}
         </NoticeMsg>
       )}
     </ProductListWrap>
@@ -114,37 +106,47 @@ const ProductListWrap = styled.div`
 const CardWrap = styled.div`
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-around;
+  margin-bottom: 30px;
 `;
 
 const Card = styled.div`
-  width: 48%;
-  margin: 1%;
+  width: 180px;
+  margin-bottom: 10px;
   padding: 10px;
   box-sizing: border-box;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
 `;
 
 const CardImg = styled.img`
+  width: 160px;
+  height: 120px;
+  background-size: cover;
   border-radius: 12px;
   margin-bottom: 5px;
 `;
 
 const ProductBadge = styled.div`
-  width: 100px;
-  height: 24px;
+  width: 50px;
+  height: 20px;
   background-color: #5cb8bc;
   color: white;
-  font-size: 14px;
+  font-size: 11px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 8px;
-  margin-bottom: 4px;
+  margin: 10px 0 0 0;
+`;
+
+const ProductPrice = styled.div`
+  font-size: 14px;
 `;
 
 const ProductTitle = styled.h1`
   font-size: 16px;
   font-weight: 700;
+  margin: 5px 0;
 `;
 
 const NoticeMsg = styled.p`

--- a/src/pages/product/components/ProductList.js
+++ b/src/pages/product/components/ProductList.js
@@ -1,10 +1,12 @@
 import styled from "@emotion/styled";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 // 상품 리스트를 보여주는 공용 컴포넌트
 
 const ProductList = ({ productList, fetchMoreData, loading, hasMore }) => {
   // Intersection Observer를 사용하여 마지막 상품이 보여질 때를 감지
+  const navigate = useNavigate();
   const observer = useRef();
   // "맨 위로 가기" 버튼의 표시 여부를 제어하는 상태
   const [showTopButton, setShowTopButton] = useState(false);
@@ -46,6 +48,7 @@ const ProductList = ({ productList, fetchMoreData, loading, hasMore }) => {
   };
 
   useEffect(() => {
+    console.log("list::", productList);
     window.addEventListener("scroll", handleScroll);
 
     return () => {
@@ -63,8 +66,7 @@ const ProductList = ({ productList, fetchMoreData, loading, hasMore }) => {
                 key={index}
                 ref={index === productList.length - 1 ? lastProductRef : null}
                 className="productCard"
-                // onClick={() => handleProductPage(product.id)}
-              >
+                onClick={() => navigate(`/web/product/${product.id}`)}>
                 {/* 추후에 상품 디테일 페이지에 연결 ! */}
                 <CardImg src={product.imgUrls[0]} alt={product.title} />
                 {index === productList.length - 1 ? (

--- a/src/pages/product/components/RecentSearches.js
+++ b/src/pages/product/components/RecentSearches.js
@@ -1,7 +1,8 @@
 import useAuthStore from "@/utils/hooks/store/useAuthStore";
 import styled from "@emotion/styled";
-import { UsersIcon } from "@heroicons/react/16/solid";
 import { useEffect, useState } from "react";
+import { getLocalStorage } from "@/pages/product/components/SaveSearchStorage";
+import { getCacheStorage } from "@/pages/product/components/SaveSearchStorage";
 
 // 검색 - 최근 검색어 목록 컴포넌트
 const RecentSearches = ({ searchTerm, handleSearchSubmit }) => {
@@ -11,15 +12,11 @@ const RecentSearches = ({ searchTerm, handleSearchSubmit }) => {
   useEffect(() => {
     let storedSearches = [];
 
-    if (isAuthenticated && accessToken) {
-      // 로그인 & 토큰 유효 사용자일 때
-      const userTokenSearches =
-        (JSON.parse(localStorage.getItem("RecentSearches")) || [])[0] || {};
-
-      storedSearches = userTokenSearches.keyword || [];
-    } else {
-      // 미로그인 사용자일 때
-      storedSearches = [];
+    try {
+      // 로컬 스토리지 사용할 수 없을 때 브라우저 캐시 사용
+      storedSearches = getLocalStorage(isAuthenticated, accessToken);
+    } catch (error) {
+      storedSearches = getCacheStorage(isAuthenticated, accessToken);
     }
 
     setRecentSearches(storedSearches);

--- a/src/pages/product/components/RecentSearches.js
+++ b/src/pages/product/components/RecentSearches.js
@@ -1,20 +1,29 @@
+import useAuthStore from "@/utils/hooks/store/useAuthStore";
 import styled from "@emotion/styled";
+import { UsersIcon } from "@heroicons/react/16/solid";
 import { useEffect, useState } from "react";
 
 // 검색 - 최근 검색어 목록 컴포넌트
 const RecentSearches = ({ searchTerm, handleSearchSubmit }) => {
+  const { isAuthenticated, accessToken } = useAuthStore();
   const [recentSearches, setRecentSearches] = useState([]);
 
-  const handleClearRecentSearches = () => {
-    localStorage.removeItem("RecentSearches");
-    setRecentSearches([]);
-  };
-
   useEffect(() => {
-    const storedSearches =
-      JSON.parse(localStorage.getItem("RecentSearches")) || [];
+    let storedSearches = [];
+
+    if (isAuthenticated && accessToken) {
+      // 로그인 & 토큰 유효 사용자일 때
+      const userTokenSearches =
+        (JSON.parse(localStorage.getItem("RecentSearches")) || [])[0] || {};
+
+      storedSearches = userTokenSearches.keyword || [];
+    } else {
+      // 미로그인 사용자일 때
+      storedSearches = [];
+    }
+
     setRecentSearches(storedSearches);
-  }, [searchTerm]);
+  }, [searchTerm, isAuthenticated, accessToken]);
 
   return (
     <>
@@ -22,12 +31,12 @@ const RecentSearches = ({ searchTerm, handleSearchSubmit }) => {
         <RecentWrap>
           <ResentTitle>최근 검색어</ResentTitle>
           <div>
-            {recentSearches.map((search, index) => (
+            {recentSearches.map((word, index) => (
               <RecentWordBadge
                 className="badge badge-primary badge-md"
                 key={index}
-                onClick={() => handleSearchSubmit(search)}>
-                {search.length > 6 ? `${search.slice(0, 5)}..` : search}
+                onClick={() => handleSearchSubmit(word)}>
+                {word.length > 6 ? `${word.slice(0, 5)}..` : word}
               </RecentWordBadge>
             ))}
           </div>

--- a/src/pages/product/components/SaveSearchStorage.js
+++ b/src/pages/product/components/SaveSearchStorage.js
@@ -1,0 +1,143 @@
+// 임시로 사용할 브라우저 캐시 스토리지 선언
+export const cacheStorage = {
+  cache: {},
+  getItem(key) {
+    return this.cache[key] || null;
+  },
+  setItem(key, value) {
+    this.cache[key] = value;
+  },
+  removeItem(key) {
+    delete this.cache[key];
+  },
+  clear() {
+    this.cache = {};
+  }
+};
+
+// 로컬 스토리지에 최근 검색어 저장
+export const saveLocalStorage = (word, isAuthenticated, accessToken) => {
+  let updatedSearches;
+
+  // 로컬 스토리지에서 최근 검색어 가져옴
+  const existingSearches =
+    JSON.parse(localStorage.getItem("RecentSearches")) || [];
+
+  if (isAuthenticated) {
+    // 로그인 되어있는 경우, 저장된 스토리지의 토큰과 로그인한 유저의 토큰 값 비교
+    const existingTokenIndex = existingSearches.findIndex(
+      (item) => item.token === accessToken
+    );
+
+    if (existingTokenIndex !== -1) {
+      // 이미 해당 토큰이 존재하는 경우, 해당 토큰의 검색어 업데이트
+      updatedSearches = existingSearches.map((item, index) =>
+        index === existingTokenIndex
+          ? {
+              token: accessToken,
+              // 새로운 검색어를 추가하고 중복 제거 후 최대 4개까지 유지
+              keyword: [word, ...item.keyword]
+                .filter((keyword, i, self) => self.indexOf(keyword) === i)
+                .slice(0, 4)
+            }
+          : item
+      );
+    } else {
+      // 해당 토큰이 존재하지 않는 경우, 새로운 토큰과 검색어를 추가
+      updatedSearches = [
+        ...existingSearches,
+        { token: accessToken, keyword: [word] }
+      ];
+    }
+  } else {
+    return;
+  }
+
+  localStorage.setItem("RecentSearches", JSON.stringify(updatedSearches));
+};
+
+// 로컬 스토리지에 저장된 최근 검색어 조회
+export const getLocalStorage = (isAuthenticated, accessToken) => {
+  let storedSearches = [];
+
+  if (isAuthenticated && accessToken) {
+    // 로그인 및 유효한 토큰을 가진 사용자인 경우
+
+    // 로컬 스토리지에서 "RecentSearches" 키의 값을 가져와 파싱
+    const userTokenSearches =
+      (JSON.parse(localStorage.getItem("RecentSearches")) || [])[0] || {};
+
+    // 해당 토큰의 최근 검색어를 가져오거나, 값이 없으면 빈 배열 사용
+    storedSearches = userTokenSearches.keyword || [];
+  }
+  // 최종적으로 로그인 상태가 아니거나 토큰이 유효하지 않은 경우 빈 배열 반환
+  return storedSearches;
+};
+
+// 캐시 스토리지에 최근 검색어 저장
+export const saveCacheStorage = (word, isAuthenticated, accessToken) => {
+  let updatedSearches;
+
+  const existingSearches =
+    JSON.parse(cacheStorage.getItem("RecentSearches")) || [];
+
+  if (isAuthenticated) {
+    // 로그인 되어있는 경우, 저장된 스토리지의 토큰과 로그인한 유저의 토큰 값 비교
+    const existingTokenIndex = existingSearches.findIndex(
+      (item) => item.token === accessToken
+    );
+
+    if (existingTokenIndex !== -1) {
+      // 이미 해당 토큰이 존재하는 경우, 해당 토큰의 검색어 업데이트
+      updatedSearches = existingSearches.map((item, index) =>
+        index === existingTokenIndex
+          ? {
+              token: accessToken,
+              // 새로운 검색어를 추가하고 중복 제거 후 최대 4개까지 유지
+              keyword: [word, ...item.keyword]
+                .filter((keyword, i, self) => self.indexOf(keyword) === i)
+                .slice(0, 4)
+            }
+          : item
+      );
+    } else {
+      // 해당 토큰이 존재하지 않는 경우, 새로운 토큰과 검색어를 추가
+      updatedSearches = [
+        ...existingSearches,
+        { token: accessToken, keyword: [word] }
+      ];
+    }
+  } else {
+    return;
+  }
+
+  cacheStorage.setItem("RecentSearches", JSON.stringify(updatedSearches));
+};
+
+// 캐시 스토리지에 저장된 최근 검색어 조회
+export const getCacheStorage = (isAuthenticated, accessToken) => {
+  let storedSearches = [];
+
+  if (isAuthenticated && accessToken) {
+    // 로그인 및 유효한 토큰을 가진 사용자인 경우
+
+    // 캐시 스토리지에서 "RecentSearches" 키의 값을 가져와 파싱
+    const userTokenSearches =
+      (JSON.parse(cacheStorage.getItem("RecentSearches")) || [])[0] || {};
+
+    // 해당 토큰의 최근 검색어를 가져오거나, 값이 없으면 빈 배열 사용
+    storedSearches = userTokenSearches.keyword || [];
+  }
+  // 최종적으로 로그인 상태가 아니거나 토큰이 유효하지 않은 경우 빈 배열 반환
+  return storedSearches;
+};
+
+const SaveSearchStorage = {
+  cacheStorage,
+  saveLocalStorage,
+  getLocalStorage,
+  saveCacheStorage,
+  getCacheStorage
+};
+
+export { SaveSearchStorage };


### PR DESCRIPTION
## PR 제목 📝
- React-spinners 설치 
- 공용 Loading 컴포넌트 추가 
- React-query 사용하여, ProductList에서 api 호출, 로딩, 에러 등 일괄 처리
- 스크롤이 최상단일 때 Top버튼 미노출 처리
- 최근 검색어 저장 시 토큰 정보 함께 저장
- 브라우저 캐시에 최근 검색어 저장/조회 로직 추가
- 로컬 스토리지 사용할 수 없는 경우 try-catch로 캐시 브라우저에 저장하도록 수정
<!-- 개발한 기능 또는 해결한 이슈의 요약을 간단하게 작성합니다. -->

## 개요 📋
- 메인/검색 페이지에서 같은 api를 호출하고 있어, ProductList에서 react-query로 일괄 처리 
- 로딩, hasMore과 같은 무한 스크롤 구현 시 각 컴포넌트에서 각자 처리해야하는 불편함 해소
- 로컬 스토리지를 사용할 수 없을 때 예외처리 추가
- 로그인 된 사용자인 경우 토큰을 최근 검색어에 함께 저장하여 로그인한 유저가 검색한 목록을 보여주도록 처리
- 사용자 입장에서 1페이지(최상단)에서는 TOP버튼 미노출이 편리할 것 같아 미노출 처리
<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간략한 설명을 제공합니다. -->

