### PR TITLE
refactor: 검색 페이지 ProductList props 내용 변경, 최근검색어 저장시 토큰 대신 userId 이용하도록 수정

### DIFF
--- a/src/pages/product/ProductSearchResultPage.js
+++ b/src/pages/product/ProductSearchResultPage.js
@@ -3,9 +3,30 @@
 import styled from "@emotion/styled";
 import { useParams } from "react-router-dom";
 import ProductList from "./components/ProductList";
+import { getPublishedPosts } from "@/api/marketApi";
+import { useState } from "react";
 
 const ProductSearchResultPage = () => {
   const { keyword } = useParams(); // 검색어
+  const [productList, setProductList] = useState([]);
+
+  const getProductList = async ({ pageParam = 1 }) => {
+    // pageParam : useInfiniteQuery의 getNextPageParam에서 반환해준 값 (=다음 불러올 페이지)
+    const resData = await getPublishedPosts({
+      page: pageParam !== 1 ? pageParam : 1, // 1 페이지가 아니면 nextPage(현재+1 된 값)을 호출
+      limit: 20,
+      query: keyword ? keyword : "",
+      orderBy: "createdAt",
+      direction: "asc"
+    });
+
+    const { page, lastPage, data: responseData } = resData.data;
+    setProductList((prevList) => [...prevList, ...responseData]);
+
+    // return은 아래 useInfiniteQuery에서 getNextPageParam으로 전달
+    // page 뜻을 전달하기 위해 이름 curPage로 전달
+    return { curPage: page, lastPage };
+  };
 
   return (
     <div>
@@ -14,7 +35,12 @@ const ProductSearchResultPage = () => {
         결과입니다.
       </SearchResultText>
 
-      <ProductList keyword={keyword} />
+      <ProductList
+        getProductList={getProductList}
+        productList={productList}
+        keyword={keyword}
+        queryKey={["HomeProductList"]}
+      />
     </div>
   );
 };

--- a/src/pages/product/ProductsSearchPage.js
+++ b/src/pages/product/ProductsSearchPage.js
@@ -26,7 +26,7 @@ const ProductsSearchPage = () => {
   const handleSearchSubmit = (current) => {
     let searchWord;
 
-    console.log("type::", typeof current);
+    // console.log("type::", typeof current);
     if (typeof current === "string") {
       // 최근 검색어를 클릭한 경우
       searchWord = current.trim();

--- a/src/pages/product/ProductsSearchPage.js
+++ b/src/pages/product/ProductsSearchPage.js
@@ -9,7 +9,7 @@ import {
 
 const ProductsSearchPage = () => {
   const navigate = useNavigate();
-  const { isAuthenticated, accessToken } = useAuthStore();
+  const { isAuthenticated, id: loginId } = useAuthStore();
   const [inputVal, setInputVal] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
 
@@ -17,9 +17,9 @@ const ProductsSearchPage = () => {
     // 최근 검색어 저장 로직 추가
     // 로컬 스토리지 사용할 수 없을 때 브라우저 캐시 사용
     try {
-      saveLocalStorage(word, isAuthenticated, accessToken);
+      saveLocalStorage(word, isAuthenticated, loginId);
     } catch (error) {
-      saveCacheStorage(word, isAuthenticated, accessToken);
+      saveCacheStorage(word, isAuthenticated, loginId);
     }
   };
 

--- a/src/pages/product/components/RecentSearches.js
+++ b/src/pages/product/components/RecentSearches.js
@@ -6,7 +6,7 @@ import { getCacheStorage } from "@/pages/product/components/SaveSearchStorage";
 
 // 검색 - 최근 검색어 목록 컴포넌트
 const RecentSearches = ({ searchTerm, handleSearchSubmit }) => {
-  const { isAuthenticated, accessToken } = useAuthStore();
+  const { isAuthenticated, id: loginId } = useAuthStore();
   const [recentSearches, setRecentSearches] = useState([]);
 
   useEffect(() => {
@@ -14,13 +14,13 @@ const RecentSearches = ({ searchTerm, handleSearchSubmit }) => {
 
     try {
       // 로컬 스토리지 사용할 수 없을 때 브라우저 캐시 사용
-      storedSearches = getLocalStorage(isAuthenticated, accessToken);
+      storedSearches = getLocalStorage(isAuthenticated, loginId);
     } catch (error) {
-      storedSearches = getCacheStorage(isAuthenticated, accessToken);
+      storedSearches = getCacheStorage(isAuthenticated, loginId);
     }
 
     setRecentSearches(storedSearches);
-  }, [searchTerm, isAuthenticated, accessToken]);
+  }, [searchTerm, isAuthenticated, loginId]);
 
   return (
     <>

--- a/src/pages/product/components/SaveSearchStorage.js
+++ b/src/pages/product/components/SaveSearchStorage.js
@@ -16,7 +16,7 @@ export const cacheStorage = {
 };
 
 // 로컬 스토리지에 최근 검색어 저장
-export const saveLocalStorage = (word, isAuthenticated, accessToken) => {
+export const saveLocalStorage = (word, isAuthenticated, loginId) => {
   let updatedSearches;
 
   // 로컬 스토리지에서 최근 검색어 가져옴
@@ -24,17 +24,17 @@ export const saveLocalStorage = (word, isAuthenticated, accessToken) => {
     JSON.parse(localStorage.getItem("RecentSearches")) || [];
 
   if (isAuthenticated) {
-    // 로그인 되어있는 경우, 저장된 스토리지의 토큰과 로그인한 유저의 토큰 값 비교
-    const existingTokenIndex = existingSearches.findIndex(
-      (item) => item.token === accessToken
+    // 로그인 되어있는 경우, 저장된 스토리지의 id와 로그인한 유저의 id 값 비교
+    const existingIdIndex = existingSearches.findIndex(
+      (item) => item.userId === loginId
     );
 
-    if (existingTokenIndex !== -1) {
-      // 이미 해당 토큰이 존재하는 경우, 해당 토큰의 검색어 업데이트
+    if (existingIdIndex !== -1) {
+      // 이미 해당 id가 존재하는 경우, 해당 id의 검색어 업데이트
       updatedSearches = existingSearches.map((item, index) =>
-        index === existingTokenIndex
+        index === existingIdIndex
           ? {
-              token: accessToken,
+              userId: loginId,
               // 새로운 검색어를 추가하고 중복 제거 후 최대 4개까지 유지
               keyword: [word, ...item.keyword]
                 .filter((keyword, i, self) => self.indexOf(keyword) === i)
@@ -43,10 +43,10 @@ export const saveLocalStorage = (word, isAuthenticated, accessToken) => {
           : item
       );
     } else {
-      // 해당 토큰이 존재하지 않는 경우, 새로운 토큰과 검색어를 추가
+      // 해당 id가 존재하지 않는 경우, 새로운 userId와 검색어를 추가
       updatedSearches = [
         ...existingSearches,
-        { token: accessToken, keyword: [word] }
+        { userId: loginId, keyword: [word] }
       ];
     }
   } else {
@@ -57,42 +57,42 @@ export const saveLocalStorage = (word, isAuthenticated, accessToken) => {
 };
 
 // 로컬 스토리지에 저장된 최근 검색어 조회
-export const getLocalStorage = (isAuthenticated, accessToken) => {
+export const getLocalStorage = (isAuthenticated, loginId) => {
   let storedSearches = [];
 
-  if (isAuthenticated && accessToken) {
-    // 로그인 및 유효한 토큰을 가진 사용자인 경우
+  if (isAuthenticated && loginId) {
+    // 로그인 및 유효한 id를 가진 사용자인 경우
 
     // 로컬 스토리지에서 "RecentSearches" 키의 값을 가져와 파싱
-    const userTokenSearches =
+    const userIdSearches =
       (JSON.parse(localStorage.getItem("RecentSearches")) || [])[0] || {};
 
-    // 해당 토큰의 최근 검색어를 가져오거나, 값이 없으면 빈 배열 사용
-    storedSearches = userTokenSearches.keyword || [];
+    // 해당 유저 id의 최근 검색어를 가져오거나, 값이 없으면 빈 배열 사용
+    storedSearches = userIdSearches.keyword || [];
   }
-  // 최종적으로 로그인 상태가 아니거나 토큰이 유효하지 않은 경우 빈 배열 반환
+  // 최종적으로 로그인 상태가 아니거나 id가 유효하지 않은 경우 빈 배열 반환
   return storedSearches;
 };
 
 // 캐시 스토리지에 최근 검색어 저장
-export const saveCacheStorage = (word, isAuthenticated, accessToken) => {
+export const saveCacheStorage = (word, isAuthenticated, loginId) => {
   let updatedSearches;
 
   const existingSearches =
     JSON.parse(cacheStorage.getItem("RecentSearches")) || [];
 
   if (isAuthenticated) {
-    // 로그인 되어있는 경우, 저장된 스토리지의 토큰과 로그인한 유저의 토큰 값 비교
-    const existingTokenIndex = existingSearches.findIndex(
-      (item) => item.token === accessToken
+    // 로그인 되어있는 경우, 저장된 스토리지의 id와 로그인한 유저의 id 값 비교
+    const existingIdIndex = existingSearches.findIndex(
+      (item) => item.userId === loginId
     );
 
-    if (existingTokenIndex !== -1) {
-      // 이미 해당 토큰이 존재하는 경우, 해당 토큰의 검색어 업데이트
+    if (existingIdIndex !== -1) {
+      // 이미 해당 id가 존재하는 경우, 해당 id의 검색어 업데이트
       updatedSearches = existingSearches.map((item, index) =>
-        index === existingTokenIndex
+        index === existingIdIndex
           ? {
-              token: accessToken,
+              userId: loginId,
               // 새로운 검색어를 추가하고 중복 제거 후 최대 4개까지 유지
               keyword: [word, ...item.keyword]
                 .filter((keyword, i, self) => self.indexOf(keyword) === i)
@@ -101,10 +101,10 @@ export const saveCacheStorage = (word, isAuthenticated, accessToken) => {
           : item
       );
     } else {
-      // 해당 토큰이 존재하지 않는 경우, 새로운 토큰과 검색어를 추가
+      // 해당 id가 존재하지 않는 경우, 새로운 userId와 검색어를 추가
       updatedSearches = [
         ...existingSearches,
-        { token: accessToken, keyword: [word] }
+        { userId: loginId, keyword: [word] }
       ];
     }
   } else {
@@ -115,20 +115,20 @@ export const saveCacheStorage = (word, isAuthenticated, accessToken) => {
 };
 
 // 캐시 스토리지에 저장된 최근 검색어 조회
-export const getCacheStorage = (isAuthenticated, accessToken) => {
+export const getCacheStorage = (isAuthenticated, loginId) => {
   let storedSearches = [];
 
-  if (isAuthenticated && accessToken) {
-    // 로그인 및 유효한 토큰을 가진 사용자인 경우
+  if (isAuthenticated && loginId) {
+    // 로그인 및 유효한 id 가진 사용자인 경우
 
     // 캐시 스토리지에서 "RecentSearches" 키의 값을 가져와 파싱
-    const userTokenSearches =
+    const userIdSearches =
       (JSON.parse(cacheStorage.getItem("RecentSearches")) || [])[0] || {};
 
-    // 해당 토큰의 최근 검색어를 가져오거나, 값이 없으면 빈 배열 사용
-    storedSearches = userTokenSearches.keyword || [];
+    // 해당 id의 최근 검색어를 가져오거나, 값이 없으면 빈 배열 사용
+    storedSearches = userIdSearches.keyword || [];
   }
-  // 최종적으로 로그인 상태가 아니거나 토큰이 유효하지 않은 경우 빈 배열 반환
+  // 최종적으로 로그인 상태가 아니거나 id가 유효하지 않은 경우 빈 배열 반환
   return storedSearches;
 };
 


### PR DESCRIPTION
## PR 제목 📝
검색 페이지 ProductList props 내용 변경
최근검색어 저장 시 토큰 대신 userId 이용하도록 수정
<!-- 개발한 기능 또는 해결한 이슈의 요약을 간단하게 작성합니다. -->

## 개요 📋
ProductList 구조 변경하면서 검색 페이지 props 누락되어 추가
최근검색어 저장 시 store에 저장된 id값을 이용해 스토리지에 저장
<!-- 이 PR이 해결하려는 문제 또는 추가하려는 기능에 대한 간략한 설명을 제공합니다. -->

